### PR TITLE
Ben

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -7,51 +7,12 @@
   packages = ["."]
   pruneopts = "UT"
   revision = "f46fb7ef125ee49d7b4219e50386b304c4300fbb"
-  source = "git@github.com:pusher/jwt-go.git"
+  source = "github.com/pusher/jwt-go.git"
   version = "v3.0.1"
-
-[[projects]]
-  branch = "master"
-  digest = "1:c822b34344031b25ffa32de9384a5059abd019171d4a131437daf776bd0a3b32"
-  name = "golang.org/x/net"
-  packages = [
-    "http/httpguts",
-    "http2",
-    "http2/hpack",
-    "idna",
-  ]
-  pruneopts = "UT"
-  revision = "161cd47e91fd58ac17490ef4d742dc98bb4cf60e"
-
-[[projects]]
-  digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
-  name = "golang.org/x/text"
-  packages = [
-    "collate",
-    "collate/build",
-    "internal/colltab",
-    "internal/gen",
-    "internal/tag",
-    "internal/triegen",
-    "internal/ucd",
-    "language",
-    "secure/bidirule",
-    "transform",
-    "unicode/bidi",
-    "unicode/cldr",
-    "unicode/norm",
-    "unicode/rangetable",
-  ]
-  pruneopts = "UT"
-  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
-  version = "v0.3.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/pusher/jwt-go",
-    "golang.org/x/net/http2",
-  ]
+  input-imports = ["github.com/pusher/jwt-go"]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,8 +31,5 @@
 
 [[constraint]]
   name = "github.com/pusher/jwt-go"
-  source = "git@github.com:pusher/jwt-go.git"
-
-[[override]]
-  name = "golang.org/x/net"
-  branch = "master"
+  source = "github.com/pusher/jwt-go.git"
+  version = "3.0.1"

--- a/authenticator.go
+++ b/authenticator.go
@@ -76,7 +76,7 @@ func (auth *authenticator) Authenticate(
 func (auth *authenticator) GenerateAccessToken(options AuthenticateOptions) (TokenWithExpiry, error) {
 	now := time.Now()
 	var tokenExpiry time.Duration
-	if options.TokenExpiry != nil {
+	if options.TokenExpiry == nil {
 		tokenExpiry = defaultTokenExpiry
 	} else {
 		tokenExpiry = *options.TokenExpiry

--- a/base_client.go
+++ b/base_client.go
@@ -8,8 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"time"
-
-	"golang.org/x/net/http2"
 )
 
 const authorizationHeader = "Authorization"
@@ -22,7 +20,6 @@ type BaseClient interface {
 // BaseClientOptions includes configuration options for a new base client
 type BaseClientOptions struct {
 	Host               string
-	Unencrypted        bool
 	Jwt                *string
 	TLSConfig          *tls.Config
 	Timeout            time.Duration
@@ -57,11 +54,7 @@ func newBaseClient(options BaseClientOptions) *baseClient {
 	c := new(baseClient)
 	c.host = options.Host
 	c.jwt = options.Jwt
-	if options.Unencrypted == true {
-		c.schema = "http"
-	} else {
-		c.schema = "https"
-	}
+	c.schema = "https"
 
 	if options.TLSConfig != nil {
 		transport := &http.Transport{
@@ -70,9 +63,6 @@ func newBaseClient(options BaseClientOptions) *baseClient {
 			DisableCompression: true,
 		}
 
-		if options.TLSConfig.NextProtos == nil || strSliceContains(options.TLSConfig.NextProtos, "h2") {
-			_ = http2.ConfigureTransport(transport)
-		}
 		c.http = http.Client{
 			Transport: transport,
 			Timeout:   options.Timeout,

--- a/helpers.go
+++ b/helpers.go
@@ -59,7 +59,7 @@ func getinstanceLocatorComponents(
 	return components[0], components[1], components[2], nil
 }
 
-// Splits the key to retreieve the public key and secret
+// Splits the key to retrieve the public key and secret
 func getKeyComponents(key string) (keyID string, keySecret string, err error) {
 	components, err := getColonSeperatedComponents(key, 2)
 	if err != nil {


### PR DESCRIPTION
### What?

Various tidy-ups:

* Remove support for http, all connections must be encrypted.
* Don't use x/net, net/http supports h2.
* h2 should be negotiated over http.
* Pin pusher/jwt-go to major version 3.
* Use http protocol for pusher/jwt-go repo.
* GenerateAccessToken options.TokenExpiry was incorrectly used.

### Why?



----

- [ ] README updated if you changed the API?

----

CC @pusher/sigsdk
