### PR TITLE
Token expiry should be a unix timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/pusher/pusher-platform-go/compare/0.1.0...HEAD)
+## [Unreleased](https://github.com/pusher/pusher-platform-go/compare/0.1.1...HEAD)
+
+## [0.1.1]
+
+- Fix token expiry time. It was previously a string of the time object, but we require a timestamp.
 
 ## [0.1.0]
 

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -85,7 +85,7 @@ func (auth *authenticator) GenerateAccessToken(options Options) (TokenWithExpiry
 		"instance": auth.instanceID,
 		"iss":      "api_keys/" + auth.keyID,
 		"iat":      now.Unix(),
-		"exp":      now.Add(tokenExpiry),
+		"exp":      now.Add(tokenExpiry).Unix(),
 	}
 
 	if options.UserID != nil {


### PR DESCRIPTION
### What?

The `exp` claim in the token was being set incorrectly. It just a stringified version of `time.Time`. However, we require a unix timestamp.

### Why?

Because its wrong.


----

- [ ] README updated if you changed the API?

----

CC @pusher/sigsdk