### PR TITLE
Fix token issuer

### DIFF
--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -35,7 +35,7 @@ type authenticator struct {
 func New(instanceID, keyID, keySecret string) Authenticator {
 	return &authenticator{
 		instanceID,
-		keySecret,
+		keyID,
 		keySecret,
 	}
 }

--- a/auth/authenticator_test.go
+++ b/auth/authenticator_test.go
@@ -60,6 +60,24 @@ func TestAuthenticateSuccess(t *testing.T) {
 			if userID != userIDClaim {
 				t.Fatalf("Expected `sub` claim to be %s, but got %s", userID, userIDClaim)
 			}
+
+			issClaim, ok := claims["iss"]
+			if !ok {
+				t.Fatal("Expected `iss` claim to exist, but it didn't")
+			}
+
+			if issClaim != "api_keys/key" {
+				t.Fatalf("Expected `iss` claim to be api_keys/key, but got %s", issClaim)
+			}
+
+			instanceClaim, ok := claims["instance"]
+			if !ok {
+				t.Fatal("Expected `instance` claim to exist, but it didn't")
+			}
+
+			if instanceClaim != "instance-id" {
+				t.Fatalf("Expected `instance` claim to be instance-id, but got %s", instanceClaim)
+			}
 		}
 	})
 


### PR DESCRIPTION
### What?

Typo meant that the token secret was being passed as the key id, which is wrong when constructing the issuer.

### Why?

We want valid tokens.

----

- [ ] README updated if you changed the API?

----

CC @pusher/sigsdk
