### PR TITLE
add constructor for Response

### DIFF
--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -47,13 +47,10 @@ func (auth *authenticator) Do(
 ) (*Response, error) {
 	grantType := payload.GrantType
 	if grantType != clientCredentialsGrantType {
-		return &Response{
-			Status: http.StatusUnprocessableEntity,
-			body: &ErrorBody{
-				ErrorType:        "token_provider/invalid_grant_type",
-				ErrorDescription: fmt.Sprintf("The grant type provided %s is unsupported", grantType),
-			},
-		}, nil
+		return NewResponse(http.StatusUnprocessableEntity, &ErrorBody{
+			ErrorType:        "token_provider/invalid_grant_type",
+			ErrorDescription: fmt.Sprintf("The grant type provided %s is unsupported", grantType),
+		}), nil
 	}
 
 	tokenWithExpiry, err := auth.GenerateAccessToken(options)
@@ -61,14 +58,11 @@ func (auth *authenticator) Do(
 		return nil, err
 	}
 
-	return &Response{
-		Status: http.StatusOK,
-		body: &TokenResponse{
-			AccessToken: tokenWithExpiry.Token,
-			TokenType:   tokenType,
-			ExpiresIn:   tokenWithExpiry.ExpiresIn,
-		},
-	}, nil
+	return NewResponse(http.StatusOK, &TokenResponse{
+		AccessToken: tokenWithExpiry.Token,
+		TokenType:   tokenType,
+		ExpiresIn:   tokenWithExpiry.ExpiresIn,
+	}), nil
 }
 
 // GenerateAccessToken returns a TokenWithExpiry based on the options provided.

--- a/auth/types.go
+++ b/auth/types.go
@@ -72,6 +72,13 @@ func (a *Response) TokenResponse() *TokenResponse {
 	return tokenResponse
 }
 
+func NewResponse(status int, body interface{}) *Response {
+	return &Response{
+		Status: status,
+		body:   body,
+	}
+}
+
 // Options contains information to configure Authenticate method calls.
 type Options struct {
 	UserID        *string                // Optional user id


### PR DESCRIPTION
### What?
Introducing a public constructor for the `Response` type. To enable code from outside the package to instantiate valid Response objects.


### Why?
We are trying to write unit tests for our wrapper of the pusher platform SDK. In order to do so, we have to mock the response returned from the SDK. This is not possible for us with the current implementation because the `body` field of `Response` type is private and cannot be set from outside the package. Providing a public constructor would resolve the issue for us.


----

- [ ] README updated if you changed the API?

----

CC @pusher/sigsdk
