### PR TITLE
Expose authorizer Response body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/pusher-platform-go/compare/0.1.2...HEAD)
 
+- Expose Authorizer Response body to allow external packages to mock responses.
+
 ## [0.1.2]
 
 - Fix token issuer. The secret was being used to construct the issuer instead.

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -49,7 +49,7 @@ func (auth *authenticator) Do(
 	if grantType != clientCredentialsGrantType {
 		return &Response{
 			Status: http.StatusUnprocessableEntity,
-			body: &ErrorBody{
+			Body: &ErrorBody{
 				ErrorType:        "token_provider/invalid_grant_type",
 				ErrorDescription: fmt.Sprintf("The grant type provided %s is unsupported", grantType),
 			},
@@ -63,7 +63,7 @@ func (auth *authenticator) Do(
 
 	return &Response{
 		Status: http.StatusOK,
-		body: &TokenResponse{
+		Body: &TokenResponse{
 			AccessToken: tokenWithExpiry.Token,
 			TokenType:   tokenType,
 			ExpiresIn:   tokenWithExpiry.ExpiresIn,

--- a/auth/types.go
+++ b/auth/types.go
@@ -34,17 +34,18 @@ type TokenResponse struct {
 
 // Response represents data that is returned when making a call to the Authenticate method.
 //
-// It returns the status of the response, headers and the response body.
+// It returns the status of the response, headers and the response body which is
+// either an ErrorBody or a TokenResponse.
 type Response struct {
 	Status  int
 	Headers http.Header
-	body    interface{}
+	Body    interface{}
 }
 
 // Error returns the ErrorBody of the authentication response.
 func (a *Response) Error() *ErrorBody {
 	if a.Status != http.StatusOK {
-		errorBody, ok := a.body.(*ErrorBody)
+		errorBody, ok := a.Body.(*ErrorBody)
 		if !ok {
 			return nil
 		}
@@ -64,7 +65,7 @@ func (a *Response) TokenResponse() *TokenResponse {
 		return nil
 	}
 
-	tokenResponse, ok := a.body.(*TokenResponse)
+	tokenResponse, ok := a.Body.(*TokenResponse)
 	if !ok {
 		return nil
 	}


### PR DESCRIPTION
### What?
Change the private `body` field of the authorizer Response to a public `Body` field.

### Why?
To allow external packages to construct authorizer Responses in tests.

----

- [ ] README updated if you changed the API?

----

CC @pusher/sigsdk
